### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ composer require octoper/cuzzle
 ```php
 
 use Namshi\Cuzzle\Formatter\CurlFormatter;
-use GuzzleHttp\Message\Request;
+use GuzzleHttp\Psr7\Request;
 
 $request = new Request('GET', 'example.local');
 $options = [];


### PR DESCRIPTION
Request no longer exists in GuzzleHttp\Message\Request. I changed to GuzzleHttp\Psr7\Request in the readme file so that the example in the readme works.